### PR TITLE
Fix lint violations in marine_ais_tools

### DIFF
--- a/marine_ais_tools/launch/ais_parser_with_nmea_relay.launch.py
+++ b/marine_ais_tools/launch/ais_parser_with_nmea_relay.launch.py
@@ -1,3 +1,32 @@
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
@@ -7,29 +36,29 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     config = PathJoinSubstitution([
-        get_package_share_directory("marine_ais_tools"),
-        "config",
-        "parameters.yaml"
+        get_package_share_directory('marine_ais_tools'),
+        'config',
+        'parameters.yaml'
     ])
 
     nmea_relay = Node(
-        package="marine_ais_tools",
-        executable="nmea_relay",
-        name="nmea_relay",
+        package='marine_ais_tools',
+        executable='nmea_relay',
+        name='nmea_relay',
         remappings=[
-            ("/nmea", "/ais/raw"),
+            ('/nmea', '/ais/raw'),
         ],
         parameters=[config],
         emulate_tty=True
     )
 
     ais_parser = Node(
-        package="marine_ais_tools",
-        executable="ais_parser",
-        name="ais_parser",
+        package='marine_ais_tools',
+        executable='ais_parser',
+        name='ais_parser',
         remappings=[
-            ("/nmea", "/ais/raw"),
-            ("/messages", "/ais/messages"),
+            ('/nmea', '/ais/raw'),
+            ('/messages', '/ais/messages'),
         ],
         emulate_tty=True
     )

--- a/marine_ais_tools/marine_ais_tools/__init__.py
+++ b/marine_ais_tools/marine_ais_tools/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/marine_ais_tools/marine_ais_tools/ais/__init__.py
+++ b/marine_ais_tools/marine_ais_tools/ais/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/marine_ais_tools/marine_ais_tools/ais/decoder.py
+++ b/marine_ais_tools/marine_ais_tools/ais/decoder.py
@@ -1,20 +1,51 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
 # Base on: Recommendation  ITU-R  M.1371-5 (02/2014)
 
 import datetime
 
+
 def decodePayload(payload, channel, nmea):
     bits = []
     for c in payload:
-        nibble = ord(c)-48
+        nibble = ord(c) - 48
         if nibble > 40:
             nibble -= 8
         mask = 1 << 5
         while mask:
-            bits.append(bool(nibble&mask))
+            bits.append(bool(nibble & mask))
             mask = mask >> 1
-    #print len(bits),'bits'
+    # print len(bits),'bits'
 
     message = {}
     message['channel'] = channel
@@ -32,10 +63,10 @@ def decodePayload(payload, channel, nmea):
                 process = True
             if process:
                 if 'size' in details:
-                    subbits = bits[details['start_bit']:details['start_bit']+details['size']]
+                    subbits = bits[details['start_bit']:details['start_bit'] + details['size']]
                 else:
                     subbits = bits[details['start_bit']:]
-                if not 'size' in details or len(subbits) == details['size']:
+                if 'size' not in details or len(subbits) == details['size']:
                     if details['type'] == 'int':
                         message[field] = decodeSignedInt(subbits)
                     elif details['type'] == 'uint':
@@ -54,8 +85,9 @@ def decodePayload(payload, channel, nmea):
                     message_id = '24A'
                 elif message['part_number'] == 1:
                     message_id = '24B'
-    
+
     return message
+
 
 def decodeUnsignedInt(bits):
     ret = 0
@@ -65,8 +97,9 @@ def decodeUnsignedInt(bits):
             ret = ret | 1
     return ret
 
+
 def decodeSignedInt(bits):
-    if not bits[0]: # positive
+    if not bits[0]:  # positive
         return decodeUnsignedInt(bits[1:])
     # negative so two's complement
     ret = 0
@@ -77,9 +110,10 @@ def decodeSignedInt(bits):
     ret += 1
     return -ret
 
+
 def decodeString(bits, strip=True):
     ret = ''
-    for i in range(0,len(bits),6):
+    for i in range(0, len(bits), 6):
         c = decodeChar(bits[i:])
         if c == '@':
             break
@@ -88,25 +122,27 @@ def decodeString(bits, strip=True):
         return ret.rstrip()
     return ret
 
+
 def decodeChar(bits):
     code = decodeUnsignedInt(bits[:6])
     if code < 32:
         code += 64
     return chr(code)
 
+
 def decodeData(bits):
     ret = []
     i = 0
     while i < len(bits):
-        if i+8 < len(bits):
-            byte = bits[i:i+8]
+        if i + 8 < len(bits):
+            byte = bits[i:i + 8]
         else:
             byte = bits[i:]
             while len(byte) < 8:
                 byte.append(False)
         ret.append(decodeUnsignedInt(byte))
-        i+=8
-        
+        i += 8
+
     return ret
 
 
@@ -124,8 +160,9 @@ def processRateOfTurn(message):
         rot = None
         message['rate_of_turn_note'] = 'turning right at more than 5 deg per 30 sec'
     else:
-        rot = pow(rot/4.733,2.0)
+        rot = pow(rot / 4.733, 2.0)
     message['rate_of_turn'] = rot
+
 
 def processSOG(message):
     sog = message['sog']
@@ -135,8 +172,9 @@ def processSOG(message):
         sog = None
         message['sog_note'] = '102.2 knots or higher'
     else:
-        sog = sog/10.0
+        sog = sog / 10.0
     message['sog'] = sog
+
 
 def processCOG(message):
     if message['cog'] >= 3600:
@@ -149,7 +187,8 @@ def processLongitude(message):
     if message['longitude'] == 0x6791AC0:
         message['longitude'] = None
     else:
-        message['longitude']/=600000.0
+        message['longitude'] /= 600000.0
+
 
 def processLatitude(message):
     if message['latitude'] == 0x3412140:
@@ -157,9 +196,11 @@ def processLatitude(message):
     else:
         message['latitude'] /= 600000.0
 
+
 def processHeading(message):
     if message['true_heading'] >= 360:
         message['true_heading'] = None
+
 
 def processTimeStamp(message):
     return
@@ -177,10 +218,12 @@ def processTimeStamp(message):
         message['time_stamp_note'] = 'positioning system is inoperative'
     message['time_stamp'] = ts
 
+
 def processCommunicationState(message):
     bits = message['communication_state']
     state = {}
-    if message['message_id'] in (1,2,4,11) or (message['message_id'] in (9,25) and message['communication_state_selector_flag'] == 0):
+    if message['message_id'] in (1, 2, 4, 11) or (message['message_id'] in (
+            9, 25) and message['communication_state_selector_flag'] == 0):
         state['sotdma_sync_state'] = decodeUnsignedInt(bits[:2])
         state['sotdma_slot_timeout'] = decodeUnsignedInt(bits[2:5])
         if state['sotdma_slot_timeout'] in (3, 5, 7):
@@ -193,12 +236,14 @@ def processCommunicationState(message):
         if state['sotdma_slot_timeout'] == 0:
             state['sotdma_slot_offset'] = decodeUnsignedInt(bits[5:19])
 
-    if message['message_id'] in (3,)or (message['message_id'] in (9,25) and message['communication_state_selector_flag'] == 1):
+    if message['message_id'] in (3,) or (message['message_id'] in (
+            9, 25) and message['communication_state_selector_flag'] == 1):
         state['itdma_sync_state'] = decodeUnsignedInt(bits[:2])
         state['itdma_slot_increment'] = decodeUnsignedInt(bits[2:15])
         state['itdma_number_of_slots'] = decodeUnsignedInt(bits[15:18])
         state['itdma_keep_flag'] = decodeUnsignedInt(bits[18:19])
     message['communication_state'] = state
+
 
 def processUTCTime(message):
     bits = message['utc_time']
@@ -208,13 +253,17 @@ def processUTCTime(message):
     hour = decodeUnsignedInt(bits[23:28])
     minute = decodeUnsignedInt(bits[28:34])
     second = decodeUnsignedInt(bits[34:40])
-    if year == 0 or year > 9999 or month == 0 or month > 12 or day == 0 or day > 31 or hour >= 24 or minute >= 60 or second >= 60:
+    if (year == 0 or year > 9999 or month == 0 or month > 12
+            or day == 0 or day > 31 or hour >= 24
+            or minute >= 60 or second >= 60):
         message['utc_time'] = None
         return
     try:
-        message['utc_time'] = datetime.datetime(year, month, day, hour, minute, second, tzinfo=datetime.timezone.utc)
-    except: 
+        message['utc_time'] = datetime.datetime(
+            year, month, day, hour, minute, second, tzinfo=datetime.timezone.utc)
+    except BaseException:
         message['utc_time'] = None
+
 
 def processDraught(message):
     d = message['maximum_present_static_draught']
@@ -226,17 +275,20 @@ def processDraught(message):
         d /= 10.0
     message['maximum_present_static_draught'] = d
 
+
 def processBinaryData(message):
     bits = message['binary_data']
     if message['message_id'] == 17:
-        message['binary_data'] = {'differential_correction_data': decodeData(bits)}
+        message['binary_data'] = {
+            'differential_correction_data': decodeData(bits)}
         return
-    if message['message_id'] in (25,26):
+    if message['message_id'] in (25, 26):
         if message['destination_indicator'] == 1:
             bits = bits[32:]
         if message['message_id'] == 26:
             comms_bits = bits[-20:]
-            message['communication_state_selector_flag'] = decodeUnsignedInt(comms_bits[:1])
+            message['communication_state_selector_flag'] = decodeUnsignedInt(
+                comms_bits[:1])
             message['communication_state'] = comms_bits[1:]
             processCommunicationState(message)
             bits = bits[:-20]
@@ -247,13 +299,17 @@ def processBinaryData(message):
     aid['designated_area_code'] = decodeUnsignedInt(bits[0:10])
     aid['function_identifier'] = decodeUnsignedInt(bits[10:16])
     data = decodeData(bits[16:])
-    message['binary_data'] = {'application_identifier': aid, 'application_data':data}
+    message['binary_data'] = {
+        'application_identifier': aid,
+        'application_data': data}
+
 
 def processAltitude(message):
     if message['altitude'] == 4095:
         message['altitude'] = None
     elif message['altitude'] == 4094:
         message['altitude_note'] = '4096 m or higher'
+
 
 def processSOGHighSpeed(message):
     sog = message['sog']
@@ -264,283 +320,364 @@ def processSOGHighSpeed(message):
         message['sog_note'] = '1022 knots or higher'
     message['sog'] = sog
 
+
 def processLongitudeLowRes(message):
     label = 'longitude'
-    if message['message_id'] in(22, 23):
+    if message['message_id'] in (22, 23):
         if 'longitude_2' in message:
             label = 'longitude_2'
         else:
             label = 'longitude_1'
-    if message[label]== 181*600:
-        message[label] = None
-    else:
-        message[label]/=600.0
-
-def processLatitudeLowRes(message):
-    label = 'latitude'
-    if message['message_id'] in (22,23):
-        if 'latitude_2' in message:
-            label = 'latitude_2'
-        else:
-            label = 'latitude_1'
-    if message[label] == 91*600:
+    if message[label] == 181 * 600:
         message[label] = None
     else:
         message[label] /= 600.0
 
+
+def processLatitudeLowRes(message):
+    label = 'latitude'
+    if message['message_id'] in (22, 23):
+        if 'latitude_2' in message:
+            label = 'latitude_2'
+        else:
+            label = 'latitude_1'
+    if message[label] == 91 * 600:
+        message[label] = None
+    else:
+        message[label] /= 600.0
+
+
 def processTransitionalZoneSize(message):
     message['transitional_zone_size'] += 1
 
+
 def processAddressedOrBroadcast(message):
     if message['message_id'] == 22:
-        if message['addressed_or_broadcast_indicator'] == 0: #broadcast
-            message.pop('destination_id1',None)
-            message.pop('destination_id2',None)
-        else: # addressed
-            message.pop('longitude_1',None)
-            message.pop('latitude_1',None)
-            message.pop('longitude_2',None)
-            message.pop('latitude_2',None)
+        if message['addressed_or_broadcast_indicator'] == 0:  # broadcast
+            message.pop('destination_id1', None)
+            message.pop('destination_id2', None)
+        else:  # addressed
+            message.pop('longitude_1', None)
+            message.pop('latitude_1', None)
+            message.pop('longitude_2', None)
+            message.pop('latitude_2', None)
+
 
 def processVendorID(message):
     bits = message['vendor_id']
-    id = {}
-    id['manufacturers_id'] = decodeString(bits[:18])
-    id['unit_model_code'] = decodeUnsignedInt(bits[18:22])
-    id['unit_serial_number'] = decodeUnsignedInt(bits[22:42])
-    message['vendor_id'] = id
+    vid = {}
+    vid['manufacturers_id'] = decodeString(bits[:18])
+    vid['unit_model_code'] = decodeUnsignedInt(bits[18:22])
+    vid['unit_serial_number'] = decodeUnsignedInt(bits[22:42])
+    message['vendor_id'] = vid
+
 
 def processDestinationID(message):
     if message['message_id'] == 25:
         if message['destination_indicator'] == 0:
             message.pop('destination_id', None)
 
+
 def processSOGLowRes(message):
     if message['sog'] == 63:
         message['sog'] = None
+
 
 def processCOGLowRes(message):
     if message['cog'] >= 360:
         message['cog'] = None
 
+
 ais_fields_table = {
-    'message_id':          {None:   {'start_bit':0,   'size':6,  'type':'uint'}},
-    'repeat_indicator':    {None:   {'start_bit':6,   'size':2,  'type':'uint'}},
-    'id':                  {None:   {'start_bit':8,   'size':30, 'type':'uint'}},
-    'navigational_status': {(1,2,3):{'start_bit':38,  'size':4,  'type':'uint'},
-                            (27,):  {'start_bit':40,  'size':4,  'type':'uint'}},
-    'part_number':         {(24,):  {'start_bit':38,   'size':2,  'type':'uint'}},
+    'message_id': {None: {'start_bit': 0, 'size': 6, 'type': 'uint'}},
+    'repeat_indicator': {None: {'start_bit': 6, 'size': 2, 'type': 'uint'}},
+    'id': {None: {'start_bit': 8, 'size': 30, 'type': 'uint'}},
+    'navigational_status': {(1, 2, 3): {'start_bit': 38, 'size': 4, 'type': 'uint'},
+                            (27,): {'start_bit': 40, 'size': 4, 'type': 'uint'}},
+    'part_number': {(24,): {'start_bit': 38, 'size': 2, 'type': 'uint'}},
     'destination_indicator':
-                           {(25,26):{'start_bit':38,   'size':1,  'type':'uint'}},
+    {(25, 26): {'start_bit': 38, 'size': 1, 'type': 'uint'}},
     'binary_data_flag':
-                           {(25,26):{'start_bit':39,   'size':1,  'type':'uint'}},
-    'rate_of_turn':        {(1,2,3):{'start_bit':42,  'size':8,  'type':'int',  'post':processRateOfTurn}},
-    'sog':                 {(1,2,3):{'start_bit':50,  'size':10, 'type':'uint', 'post':processSOG},
-                            (9,):   {'start_bit':50,  'size':10, 'type':'uint', 'post':processSOGHighSpeed},
-                            (18,19):{'start_bit':46,  'size':10, 'type':'uint', 'post':processSOG},
-                            (27,):  {'start_bit':79,  'size':6, 'type':'uint',  'post':processSOGLowRes},},
-    'position_accuracy':   {(1,2,3,9):
-                                    {'start_bit':60,  'size':1,  'type':'uint'},
-                            (4,11): {'start_bit':78,  'size':1,  'type':'uint'},
-                            (18,19):{'start_bit':56,  'size':1,  'type':'uint'},
-                            (21,):  {'start_bit':163, 'size':1,  'type':'uint'},
-                            (27,):  {'start_bit':38,  'size':1,  'type':'uint'}},
-    'longitude':           {(1,2,3,9):
-                                    {'start_bit':61,  'size':28, 'type':'int',  'post':processLongitude},
-                            (4,11): {'start_bit':79,  'size':28, 'type':'int',  'post':processLongitude},
-                            (17,):  {'start_bit':40,  'size':18, 'type':'int',  'post':processLongitudeLowRes},
-                            (18,19):{'start_bit':57,  'size':28, 'type':'int',  'post':processLongitude},
-                            (21,):  {'start_bit':164, 'size':28, 'type':'int',  'post':processLongitude},
-                            (27,):  {'start_bit':44,  'size':18, 'type':'int',  'post':processLongitudeLowRes},},
-    'latitude':            {(1,2,3,9):
-                                    {'start_bit':89,  'size':27, 'type':'int',  'post':processLatitude},
-                            (4,11): {'start_bit':107, 'size':27, 'type':'int',  'post':processLatitude},
-                            (17,):  {'start_bit':58,  'size':17, 'type':'int',  'post':processLatitudeLowRes},
-                            (18,19):{'start_bit':85,  'size':27, 'type':'int',  'post':processLatitude},
-                            (21,):  {'start_bit':192, 'size':27, 'type':'int',  'post':processLatitude},
-                            (27,):  {'start_bit':62,  'size':17, 'type':'int',  'post':processLatitudeLowRes}},
-    'cog':                 {(1,2,3,9):
-                                    {'start_bit':116, 'size':12, 'type':'uint', 'post':processCOG},
-                            (18,19):{'start_bit':112, 'size':12, 'type':'uint', 'post':processCOG},
-                            (27,)  :{'start_bit':85,  'size':9,  'type':'uint', 'post':processCOGLowRes}},
-    'true_heading':        {(1,2,3):{'start_bit':128, 'size':9,  'type':'uint', 'post':processHeading},
-                            (18,19):{'start_bit':124, 'size':9,  'type':'uint', 'post':processHeading}},
-    'time_stamp':          {(1,2,3):{'start_bit':137, 'size':6,  'type':'uint', 'post':processTimeStamp},
-                            (9,):   {'start_bit':128, 'size':6,  'type':'uint', 'post':processTimeStamp},
-                            (18,19):{'start_bit':133, 'size':6,  'type':'uint', 'post':processTimeStamp},
-                            (21,)  :{'start_bit':257, 'size':6,  'type':'uint', 'post':processTimeStamp}},
+    {(25, 26): {'start_bit': 39, 'size': 1, 'type': 'uint'}},
+    'rate_of_turn': {
+        (1, 2, 3): {
+            'start_bit': 42, 'size': 8,
+            'type': 'int', 'post': processRateOfTurn,
+        },
+    },
+    'sog': {(1, 2, 3): {'start_bit': 50, 'size': 10, 'type': 'uint', 'post': processSOG},
+            (9,): {'start_bit': 50, 'size': 10, 'type': 'uint', 'post': processSOGHighSpeed},
+            (18, 19): {'start_bit': 46, 'size': 10, 'type': 'uint', 'post': processSOG},
+            (27,): {'start_bit': 79, 'size': 6, 'type': 'uint', 'post': processSOGLowRes}, },
+    'position_accuracy': {(1, 2, 3, 9):
+                          {'start_bit': 60, 'size': 1, 'type': 'uint'},
+                          (4, 11): {'start_bit': 78, 'size': 1, 'type': 'uint'},
+                          (18, 19): {'start_bit': 56, 'size': 1, 'type': 'uint'},
+                          (21,): {'start_bit': 163, 'size': 1, 'type': 'uint'},
+                          (27,): {'start_bit': 38, 'size': 1, 'type': 'uint'}},
+    'longitude': {(1, 2, 3, 9):
+                  {'start_bit': 61, 'size': 28, 'type': 'int',
+                      'post': processLongitude},
+                  (4, 11): {
+                      'start_bit': 79, 'size': 28,
+                      'type': 'int', 'post': processLongitude},
+                  (17,): {
+                      'start_bit': 40, 'size': 18,
+                      'type': 'int', 'post': processLongitudeLowRes},
+                  (18, 19): {
+                      'start_bit': 57, 'size': 28,
+                      'type': 'int', 'post': processLongitude},
+                  (21,): {
+                      'start_bit': 164, 'size': 28,
+                      'type': 'int', 'post': processLongitude},
+                  (27,): {
+                      'start_bit': 44, 'size': 18,
+                      'type': 'int',
+                      'post': processLongitudeLowRes},
+                  },
+    'latitude': {(1, 2, 3, 9):
+                 {'start_bit': 89, 'size': 27,
+                     'type': 'int', 'post': processLatitude},
+                 (4, 11): {
+                     'start_bit': 107, 'size': 27,
+                     'type': 'int', 'post': processLatitude},
+                 (17,): {
+                     'start_bit': 58, 'size': 17,
+                     'type': 'int', 'post': processLatitudeLowRes},
+                 (18, 19): {
+                     'start_bit': 85, 'size': 27,
+                     'type': 'int', 'post': processLatitude},
+                 (21,): {
+                     'start_bit': 192, 'size': 27,
+                     'type': 'int', 'post': processLatitude},
+                 (27,): {
+                     'start_bit': 62, 'size': 17,
+                     'type': 'int',
+                     'post': processLatitudeLowRes}},
+    'cog': {(1, 2, 3, 9):
+            {'start_bit': 116, 'size': 12, 'type': 'uint', 'post': processCOG},
+            (18, 19): {'start_bit': 112, 'size': 12, 'type': 'uint', 'post': processCOG},
+            (27,): {'start_bit': 85, 'size': 9, 'type': 'uint', 'post': processCOGLowRes}},
+    'true_heading': {
+        (1, 2, 3): {
+            'start_bit': 128, 'size': 9,
+            'type': 'uint', 'post': processHeading},
+        (18, 19): {
+            'start_bit': 124, 'size': 9,
+            'type': 'uint', 'post': processHeading}},
+    'time_stamp': {
+        (1, 2, 3): {
+            'start_bit': 137, 'size': 6,
+            'type': 'uint', 'post': processTimeStamp},
+        (9,): {
+            'start_bit': 128, 'size': 6,
+            'type': 'uint', 'post': processTimeStamp},
+        (18, 19): {
+            'start_bit': 133, 'size': 6,
+            'type': 'uint', 'post': processTimeStamp},
+        (21,): {
+            'start_bit': 257, 'size': 6,
+            'type': 'uint', 'post': processTimeStamp}},
     'special_manoeuvre_indicator':
-                           {(1,2,3):{'start_bit':143, 'size':2,  'type':'uint'}},
-    'raim_flag':           {(1,2,3,4,11):
-                                    {'start_bit':148, 'size':1,  'type':'uint'},
-                            (9,18): {'start_bit':147, 'size':1,  'type':'uint'},
-                            (19,):  {'start_bit':305, 'size':1,  'type':'uint'},
-                            (21,):  {'start_bit':274, 'size':1,  'type':'uint'},
-                            (27,):  {'start_bit':39,  'size':1,  'type':'uint'}},
+    {(1, 2, 3): {'start_bit': 143, 'size': 2, 'type': 'uint'}},
+    'raim_flag': {(1, 2, 3, 4, 11):
+                  {'start_bit': 148, 'size': 1, 'type': 'uint'},
+                  (9, 18): {'start_bit': 147, 'size': 1, 'type': 'uint'},
+                  (19,): {'start_bit': 305, 'size': 1, 'type': 'uint'},
+                  (21,): {'start_bit': 274, 'size': 1, 'type': 'uint'},
+                  (27,): {'start_bit': 39, 'size': 1, 'type': 'uint'}},
     'communication_state_selector_flag':
-                           {(9,18):   {'start_bit':148, 'size':1,  'type':'uint'}},
-    'communication_state': {(1,2,3,4,9,11,18):
-                                    {'start_bit':149, 'size':19, 'type':'bits', 'post':processCommunicationState}},
-    'utc_time':            {(4,11): {'start_bit':38,  'size':40, 'type':'bits', 'post':processUTCTime}},
+    {(9, 18): {'start_bit': 148, 'size': 1, 'type': 'uint'}},
+    'communication_state': {
+        (1, 2, 3, 4, 9, 11, 18): {
+            'start_bit': 149, 'size': 19,
+            'type': 'bits',
+            'post': processCommunicationState}},
+    'utc_time': {(4, 11): {'start_bit': 38, 'size': 40, 'type': 'bits', 'post': processUTCTime}},
     'position_fixing_device_type':
-                           {(4,11): {'start_bit':134, 'size':4,  'type':'uint'},
-                            (5,):   {'start_bit':270, 'size':4,  'type':'uint'},
-                            (19,):  {'start_bit':301, 'size':4,  'type':'uint'},
-                            (21,):  {'start_bit':253, 'size':4,  'type':'uint'},
-                            ('24B',):
-                                    {'start_bit':142, 'size':4,  'type':'uint'}},
+    {(4, 11): {'start_bit': 134, 'size': 4, 'type': 'uint'},
+     (5,): {'start_bit': 270, 'size': 4, 'type': 'uint'},
+     (19,): {'start_bit': 301, 'size': 4, 'type': 'uint'},
+     (21,): {'start_bit': 253, 'size': 4, 'type': 'uint'},
+     ('24B',):
+     {'start_bit': 142, 'size': 4, 'type': 'uint'}},
     'long_range_transmission_control':
-                           {(4,11): {'start_bit':138, 'size':1,  'type':'uint'}},
-    'ais_version':         {(5,):   {'start_bit':38,  'size':2,  'type':'uint'}},
-    'imo_number':          {(5,):   {'start_bit':40,  'size':30, 'type':'uint'}},
-    'call_sign':           {(5,):   {'start_bit':70,  'size':42, 'type':'string'},
+    {(4, 11): {'start_bit': 138, 'size': 1, 'type': 'uint'}},
+    'ais_version': {(5,): {'start_bit': 38, 'size': 2, 'type': 'uint'}},
+    'imo_number': {(5,): {'start_bit': 40, 'size': 30, 'type': 'uint'}},
+    'call_sign': {(5,): {'start_bit': 70, 'size': 42, 'type': 'string'},
+                  ('24B',):
+                  {'start_bit': 90, 'size': 42, 'type': 'string'}},
+    'name': {(5,): {'start_bit': 112, 'size': 120, 'type': 'string'},
+             (19,): {'start_bit': 143, 'size': 120, 'type': 'string'},
+             ('24A',):
+             {'start_bit': 40, 'size': 120, 'type': 'string'}},
+    'ship_and_cargo_type': {(5,): {'start_bit': 232, 'size': 8, 'type': 'uint'},
+                            (19,): {'start_bit': 263, 'size': 8, 'type': 'uint'},
+                            (23,): {'start_bit': 114, 'size': 8, 'type': 'uint'},
                             ('24B',):
-                                    {'start_bit':90,  'size':42, 'type':'string'}},
-    'name':                {(5,):   {'start_bit':112, 'size':120,'type':'string'},
-                            (19,):  {'start_bit':143, 'size':120,'type':'string'},
-                            ('24A',):
-                                    {'start_bit':40,  'size':120,'type':'string'}},
-    'ship_and_cargo_type': {(5,):   {'start_bit':232, 'size':8,  'type':'uint'},
-                            (19,):  {'start_bit':263, 'size':8,  'type':'uint'},
-                            (23,):  {'start_bit':114, 'size':8,  'type':'uint'},
-                            ('24B',):
-                                    {'start_bit':40,  'size':8,  'type':'uint'}},
+                            {'start_bit': 40, 'size': 8, 'type': 'uint'}},
     'reference_to_bow_distance':
-                           {(5,):   {'start_bit':240, 'size':9,  'type':'uint'},
-                            (19,):  {'start_bit':271, 'size':9,  'type':'uint'},
-                            (21,):  {'start_bit':219, 'size':9,  'type':'uint'},
-                            ('24B',):
-                                    {'start_bit':132, 'size':9,  'type':'uint'}},
+    {(5,): {'start_bit': 240, 'size': 9, 'type': 'uint'},
+     (19,): {'start_bit': 271, 'size': 9, 'type': 'uint'},
+     (21,): {'start_bit': 219, 'size': 9, 'type': 'uint'},
+     ('24B',):
+     {'start_bit': 132, 'size': 9, 'type': 'uint'}},
     'reference_to_stern_distance':
-                           {(5,):   {'start_bit':249, 'size':9,  'type':'uint'},
-                            (19,):  {'start_bit':280, 'size':9,  'type':'uint'},
-                            (21,):  {'start_bit':228, 'size':9,  'type':'uint'},
-                            ('24B',):
-                                    {'start_bit':141, 'size':9,  'type':'uint'}},
+    {(5,): {'start_bit': 249, 'size': 9, 'type': 'uint'},
+     (19,): {'start_bit': 280, 'size': 9, 'type': 'uint'},
+     (21,): {'start_bit': 228, 'size': 9, 'type': 'uint'},
+     ('24B',):
+     {'start_bit': 141, 'size': 9, 'type': 'uint'}},
     'reference_to_port_distance':
-                           {(5,):   {'start_bit':258, 'size':6,  'type':'uint'},
-                            (19,):  {'start_bit':289, 'size':6,  'type':'uint'},
-                            (21,):  {'start_bit':237, 'size':6,  'type':'uint'},
-                            ('24B',):
-                                    {'start_bit':150, 'size':6,  'type':'uint'}},
+    {(5,): {'start_bit': 258, 'size': 6, 'type': 'uint'},
+     (19,): {'start_bit': 289, 'size': 6, 'type': 'uint'},
+     (21,): {'start_bit': 237, 'size': 6, 'type': 'uint'},
+     ('24B',):
+     {'start_bit': 150, 'size': 6, 'type': 'uint'}},
     'reference_to_starboard_distance':
-                           {(5,):   {'start_bit':264, 'size':6,  'type':'uint'},
-                            (19,):  {'start_bit':295, 'size':6,  'type':'uint'},
-                            (21,):  {'start_bit':243, 'size':6,  'type':'uint'},
-                            ('24B',):
-                                    {'start_bit':156, 'size':6,  'type':'uint'}},
-    'eta_month':           {(5,):   {'start_bit':274, 'size':4,  'type':'uint'}},
-    'eta_day':             {(5,):   {'start_bit':278, 'size':5,  'type':'uint'}},
-    'eta_hour':            {(5,):   {'start_bit':283, 'size':5,  'type':'uint'}},
-    'eta_minute':          {(5,):   {'start_bit':288, 'size':6,  'type':'uint'}},
+    {(5,): {'start_bit': 264, 'size': 6, 'type': 'uint'},
+     (19,): {'start_bit': 295, 'size': 6, 'type': 'uint'},
+     (21,): {'start_bit': 243, 'size': 6, 'type': 'uint'},
+     ('24B',):
+     {'start_bit': 156, 'size': 6, 'type': 'uint'}},
+    'eta_month': {(5,): {'start_bit': 274, 'size': 4, 'type': 'uint'}},
+    'eta_day': {(5,): {'start_bit': 278, 'size': 5, 'type': 'uint'}},
+    'eta_hour': {(5,): {'start_bit': 283, 'size': 5, 'type': 'uint'}},
+    'eta_minute': {(5,): {'start_bit': 288, 'size': 6, 'type': 'uint'}},
     'maximum_present_static_draught':
-                           {(5,):   {'start_bit':294, 'size':8,  'type':'uint', 'post':processDraught}},
-    'destination':         {(5,):   {'start_bit':302, 'size':120,'type':'string'}},
-    'dte':                 {(5,):   {'start_bit':422, 'size':1,  'type':'uint'},
-                            (9,):   {'start_bit':142, 'size':1,  'type':'uint'},
-                            (19,):  {'start_bit':306, 'size':1,  'type':'uint'}},
-    'sequence_number':     {(6,12): {'start_bit':38,  'size':2,  'type':'uint'}},
-    'destination_id':      {(6,10,12,25):
-                                    {'start_bit':40,  'size':30, 'type':'uint', 'post':processDestinationID}},
-    'retransmit_flag':     {(6,12): {'start_bit':70,  'size':1,  'type':'uint'}},
-    'binary_data':         {(6,):   {'start_bit':72,             'type':'bits', 'post':processBinaryData},
-                            (8,25,26):
-                                    {'start_bit':40,             'type':'bits', 'post':processBinaryData},
-                            (17,):  {'start_bit':80,             'type':'bits', 'post':processBinaryData}},
-    'destination_id1':     {(7,13,15):
-                                    {'start_bit':40,  'size':30, 'type':'uint'},
-                            (22,):  {'start_bit':87,  'size':30, 'type':'uint'}},
+    {(5,): {'start_bit': 294, 'size': 8, 'type': 'uint', 'post': processDraught}},
+    'destination': {(5,): {'start_bit': 302, 'size': 120, 'type': 'string'}},
+    'dte': {(5,): {'start_bit': 422, 'size': 1, 'type': 'uint'},
+            (9,): {'start_bit': 142, 'size': 1, 'type': 'uint'},
+            (19,): {'start_bit': 306, 'size': 1, 'type': 'uint'}},
+    'sequence_number': {(6, 12): {'start_bit': 38, 'size': 2, 'type': 'uint'}},
+    'destination_id': {
+        (6, 10, 12, 25): {
+            'start_bit': 40, 'size': 30,
+            'type': 'uint', 'post': processDestinationID}},
+    'retransmit_flag': {(6, 12): {'start_bit': 70, 'size': 1, 'type': 'uint'}},
+    'binary_data': {(6,): {'start_bit': 72, 'type': 'bits', 'post': processBinaryData},
+                    (8, 25, 26):
+                    {'start_bit': 40, 'type': 'bits', 'post': processBinaryData},
+                    (17,): {'start_bit': 80, 'type': 'bits', 'post': processBinaryData}},
+    'destination_id1': {(7, 13, 15):
+                        {'start_bit': 40, 'size': 30, 'type': 'uint'},
+                        (22,): {'start_bit': 87, 'size': 30, 'type': 'uint'}},
     'sequence_number_for_id1':
-                           {(7,13): {'start_bit':70,  'size':2,  'type':'uint'}},
-    'destination_id2':     {(7,13): {'start_bit':72,  'size':30, 'type':'uint'},
-                            (15,):  {'start_bit':110, 'size':30, 'type':'uint'},
-                            (22,):  {'start_bit':122, 'size':30, 'type':'uint'}},
+    {(7, 13): {'start_bit': 70, 'size': 2, 'type': 'uint'}},
+    'destination_id2': {(7, 13): {'start_bit': 72, 'size': 30, 'type': 'uint'},
+                        (15,): {'start_bit': 110, 'size': 30, 'type': 'uint'},
+                        (22,): {'start_bit': 122, 'size': 30, 'type': 'uint'}},
     'sequence_number_for_id2':
-                           {(7,13): {'start_bit':102, 'size':2,  'type':'uint'}},
-    'destination_id3':     {(7,13): {'start_bit':104, 'size':30, 'type':'uint'}},
+    {(7, 13): {'start_bit': 102, 'size': 2, 'type': 'uint'}},
+    'destination_id3': {(7, 13): {'start_bit': 104, 'size': 30, 'type': 'uint'}},
     'sequence_number_for_id3':
-                           {(7,13): {'start_bit':134, 'size':2,  'type':'uint'}},
-    'destination_id4':     {(7,13): {'start_bit':136, 'size':30, 'type':'uint'}},
+    {(7, 13): {'start_bit': 134, 'size': 2, 'type': 'uint'}},
+    'destination_id4': {(7, 13): {'start_bit': 136, 'size': 30, 'type': 'uint'}},
     'sequence_number_for_id4':
-                           {(7,13): {'start_bit':166, 'size':2,  'type':'uint'}},
-    'altitude':            {(9,):   {'start_bit':38,  'size':12, 'type':'uint', 'post':processAltitude}},
-    'altitude_sensor':     {(9,):   {'start_bit':134, 'size':1,  'type':'uint'}},
-    'assigned_mode_flag':  {(9,):   {'start_bit':146, 'size':1,  'type':'uint'},
-                            (19,):  {'start_bit':307, 'size':1,  'type':'uint'}},
-    'safety_related_text': {(12,):  {'start_bit':72,             'type':'string'},
-                            (14,):  {'start_bit':40,             'type':'string'}},
-    'message_id1_1':       {(15,):  {'start_bit':70,  'size':6,  'type':'uint'}},
-    'slot_offset_1_1':     {(15,):  {'start_bit':76,  'size':12, 'type':'uint'}},
-    'message_id1_2':       {(15,):  {'start_bit':90,  'size':6,  'type':'uint'}},
-    'slot_offset_1_2':     {(15,):  {'start_bit':96,  'size':12, 'type':'uint'}},
-    'message_id2_1':       {(15,):  {'start_bit':140, 'size':6,  'type':'uint'}},
-    'slot_offset_2_1':     {(15,):  {'start_bit':146, 'size':12, 'type':'uint'}},
-    'destination_id_a':    {(16,):  {'start_bit':40,  'size':30, 'type':'uint'}},
-    'offset_a':            {(16,):  {'start_bit':70,  'size':12, 'type':'uint'}},
-    'increment_a':         {(16,):  {'start_bit':82,  'size':10, 'type':'uint'}},
-    'destination_id_b':    {(16,):  {'start_bit':92,  'size':30, 'type':'uint'}},
-    'offset_b':            {(16,):  {'start_bit':122, 'size':12, 'type':'uint'}},
-    'increment_b':         {(16,):  {'start_bit':134, 'size':10, 'type':'uint'}},
-    'class_b_unit_flag':   {(18,):  {'start_bit':141, 'size':1,  'type':'uint'}},
-    'class_b_display_flag':{(18,):  {'start_bit':142, 'size':1,  'type':'uint'}},
-    'class_b_dsc_flag':    {(18,):  {'start_bit':143, 'size':1,  'type':'uint'}},
-    'class_b_band_flag':   {(18,):  {'start_bit':144, 'size':1,  'type':'uint'}},
+    {(7, 13): {'start_bit': 166, 'size': 2, 'type': 'uint'}},
+    'altitude': {(9,): {'start_bit': 38, 'size': 12, 'type': 'uint', 'post': processAltitude}},
+    'altitude_sensor': {(9,): {'start_bit': 134, 'size': 1, 'type': 'uint'}},
+    'assigned_mode_flag': {(9,): {'start_bit': 146, 'size': 1, 'type': 'uint'},
+                           (19,): {'start_bit': 307, 'size': 1, 'type': 'uint'}},
+    'safety_related_text': {(12,): {'start_bit': 72, 'type': 'string'},
+                            (14,): {'start_bit': 40, 'type': 'string'}},
+    'message_id1_1': {(15,): {'start_bit': 70, 'size': 6, 'type': 'uint'}},
+    'slot_offset_1_1': {(15,): {'start_bit': 76, 'size': 12, 'type': 'uint'}},
+    'message_id1_2': {(15,): {'start_bit': 90, 'size': 6, 'type': 'uint'}},
+    'slot_offset_1_2': {(15,): {'start_bit': 96, 'size': 12, 'type': 'uint'}},
+    'message_id2_1': {(15,): {'start_bit': 140, 'size': 6, 'type': 'uint'}},
+    'slot_offset_2_1': {(15,): {'start_bit': 146, 'size': 12, 'type': 'uint'}},
+    'destination_id_a': {(16,): {'start_bit': 40, 'size': 30, 'type': 'uint'}},
+    'offset_a': {(16,): {'start_bit': 70, 'size': 12, 'type': 'uint'}},
+    'increment_a': {(16,): {'start_bit': 82, 'size': 10, 'type': 'uint'}},
+    'destination_id_b': {(16,): {'start_bit': 92, 'size': 30, 'type': 'uint'}},
+    'offset_b': {(16,): {'start_bit': 122, 'size': 12, 'type': 'uint'}},
+    'increment_b': {(16,): {'start_bit': 134, 'size': 10, 'type': 'uint'}},
+    'class_b_unit_flag': {(18,): {'start_bit': 141, 'size': 1, 'type': 'uint'}},
+    'class_b_display_flag': {(18,): {'start_bit': 142, 'size': 1, 'type': 'uint'}},
+    'class_b_dsc_flag': {(18,): {'start_bit': 143, 'size': 1, 'type': 'uint'}},
+    'class_b_band_flag': {(18,): {'start_bit': 144, 'size': 1, 'type': 'uint'}},
     'class_b_message_22_flag':
-                           {(18,):  {'start_bit':145, 'size':1,  'type':'uint'}},
-    'mode_flag':           {(18,):  {'start_bit':146, 'size':1,  'type':'uint'}},
-    'offset_number_1':     {(20,):  {'start_bit':40,  'size':12, 'type':'uint'}},
-    'number_of_slots_1':   {(20,):  {'start_bit':52,  'size':4,  'type':'uint'}},
-    'timeout_1':           {(20,):  {'start_bit':56,  'size':3,  'type':'uint'}},
-    'increment_1':         {(20,):  {'start_bit':59,  'size':11, 'type':'uint'}},
-    'offset_number_2':     {(20,):  {'start_bit':70,  'size':12, 'type':'uint'}},
-    'number_of_slots_2':   {(20,):  {'start_bit':82,  'size':4,  'type':'uint'}},
-    'timeout_2':           {(20,):  {'start_bit':86,  'size':3,  'type':'uint'}},
-    'increment_2':         {(20,):  {'start_bit':89,  'size':11, 'type':'uint'}},
-    'offset_number_3':     {(20,):  {'start_bit':100, 'size':12, 'type':'uint'}},
-    'number_of_slots_3':   {(20,):  {'start_bit':112, 'size':4,  'type':'uint'}},
-    'timeout_3':           {(20,):  {'start_bit':116, 'size':3,  'type':'uint'}},
-    'increment_3':         {(20,):  {'start_bit':119, 'size':11, 'type':'uint'}},
-    'offset_number_4':     {(20,):  {'start_bit':130, 'size':12, 'type':'uint'}},
-    'number_of_slots_4':   {(20,):  {'start_bit':142, 'size':4,  'type':'uint'}},
-    'timeout_4':           {(20,):  {'start_bit':146, 'size':3,  'type':'uint'}},
-    'increment_4':         {(20,):  {'start_bit':149, 'size':11, 'type':'uint'}},
+    {(18,): {'start_bit': 145, 'size': 1, 'type': 'uint'}},
+    'mode_flag': {(18,): {'start_bit': 146, 'size': 1, 'type': 'uint'}},
+    'offset_number_1': {(20,): {'start_bit': 40, 'size': 12, 'type': 'uint'}},
+    'number_of_slots_1': {(20,): {'start_bit': 52, 'size': 4, 'type': 'uint'}},
+    'timeout_1': {(20,): {'start_bit': 56, 'size': 3, 'type': 'uint'}},
+    'increment_1': {(20,): {'start_bit': 59, 'size': 11, 'type': 'uint'}},
+    'offset_number_2': {(20,): {'start_bit': 70, 'size': 12, 'type': 'uint'}},
+    'number_of_slots_2': {(20,): {'start_bit': 82, 'size': 4, 'type': 'uint'}},
+    'timeout_2': {(20,): {'start_bit': 86, 'size': 3, 'type': 'uint'}},
+    'increment_2': {(20,): {'start_bit': 89, 'size': 11, 'type': 'uint'}},
+    'offset_number_3': {(20,): {'start_bit': 100, 'size': 12, 'type': 'uint'}},
+    'number_of_slots_3': {(20,): {'start_bit': 112, 'size': 4, 'type': 'uint'}},
+    'timeout_3': {(20,): {'start_bit': 116, 'size': 3, 'type': 'uint'}},
+    'increment_3': {(20,): {'start_bit': 119, 'size': 11, 'type': 'uint'}},
+    'offset_number_4': {(20,): {'start_bit': 130, 'size': 12, 'type': 'uint'}},
+    'number_of_slots_4': {(20,): {'start_bit': 142, 'size': 4, 'type': 'uint'}},
+    'timeout_4': {(20,): {'start_bit': 146, 'size': 3, 'type': 'uint'}},
+    'increment_4': {(20,): {'start_bit': 149, 'size': 11, 'type': 'uint'}},
     'type_of_aids_to_navigation':
-                           {(21,):  {'start_bit':38,  'size':5,  'type':'uint'}},
+    {(21,): {'start_bit': 38, 'size': 5, 'type': 'uint'}},
     'name_of_aids_to_navigation':
-                           {(21,):  {'start_bit':43,  'size':120,'type':'string'}},
+    {(21,): {'start_bit': 43, 'size': 120, 'type': 'string'}},
     'off_position_indicator':
-                           {(21,):  {'start_bit':263, 'size':1,  'type':'uint'}},
-    'aton_status':         {(21,):  {'start_bit':264, 'size':8,  'type':'uint'}},
-    'virtual_aton_flag':   {(21,):  {'start_bit':275, 'size':1,  'type':'uint'}},
+    {(21,): {'start_bit': 263, 'size': 1, 'type': 'uint'}},
+    'aton_status': {(21,): {'start_bit': 264, 'size': 8, 'type': 'uint'}},
+    'virtual_aton_flag': {(21,): {'start_bit': 275, 'size': 1, 'type': 'uint'}},
     'name_of_aids_to_navigation_extension':
-                           {(21,):  {'start_bit':276,            'type':'string'}},
-    'channel_a':           {(22,):  {'start_bit':40,  'size':12, 'type':'uint'}},
-    'channel_b':           {(22,):  {'start_bit':52,  'size':12, 'type':'uint'}},
-    'tx_rx_mode':          {(22,):  {'start_bit':64,  'size':4,  'type':'uint'},
-                            (23,):  {'start_bit':144, 'size':2,  'type':'uint'}},
-    'power':               {(22,):  {'start_bit':68,  'size':1,  'type':'uint'}},
-    'longitude_1':         {(22,):  {'start_bit':69,  'size':18, 'type':'int',  'post':processLongitudeLowRes},
-                            (23,):  {'start_bit':40,  'size':18, 'type':'int',  'post':processLongitudeLowRes}},
-    'latitude_1':          {(22,):  {'start_bit':87,  'size':17, 'type':'int',  'post':processLatitudeLowRes},
-                            (23,):  {'start_bit':58,  'size':17, 'type':'int',  'post':processLatitudeLowRes}},
-    'longitude_2':         {(22,):  {'start_bit':104, 'size':18, 'type':'int',  'post':processLongitudeLowRes},
-                            (23,):  {'start_bit':75,  'size':18, 'type':'int',  'post':processLongitudeLowRes}},
-    'latitude_2':          {(22,):  {'start_bit':122, 'size':17, 'type':'int',  'post':processLatitudeLowRes},
-                            (23,):  {'start_bit':93, 'size':17, 'type':'int',  'post':processLatitudeLowRes}},
+    {(21,): {'start_bit': 276, 'type': 'string'}},
+    'channel_a': {(22,): {'start_bit': 40, 'size': 12, 'type': 'uint'}},
+    'channel_b': {(22,): {'start_bit': 52, 'size': 12, 'type': 'uint'}},
+    'tx_rx_mode': {(22,): {'start_bit': 64, 'size': 4, 'type': 'uint'},
+                   (23,): {'start_bit': 144, 'size': 2, 'type': 'uint'}},
+    'power': {(22,): {'start_bit': 68, 'size': 1, 'type': 'uint'}},
+    'longitude_1': {
+        (22,): {
+            'start_bit': 69, 'size': 18,
+            'type': 'int', 'post': processLongitudeLowRes},
+        (23,): {
+            'start_bit': 40, 'size': 18,
+            'type': 'int', 'post': processLongitudeLowRes}},
+    'latitude_1': {
+        (22,): {
+            'start_bit': 87, 'size': 17,
+            'type': 'int', 'post': processLatitudeLowRes},
+        (23,): {
+            'start_bit': 58, 'size': 17,
+            'type': 'int', 'post': processLatitudeLowRes}},
+    'longitude_2': {
+        (22,): {
+            'start_bit': 104, 'size': 18,
+            'type': 'int', 'post': processLongitudeLowRes},
+        (23,): {
+            'start_bit': 75, 'size': 18,
+            'type': 'int', 'post': processLongitudeLowRes}},
+    'latitude_2': {
+        (22,): {
+            'start_bit': 122, 'size': 17,
+            'type': 'int', 'post': processLatitudeLowRes},
+        (23,): {
+            'start_bit': 93, 'size': 17,
+            'type': 'int', 'post': processLatitudeLowRes}},
     'addressed_or_broadcast_indicator':
-                           {(22,):  {'start_bit':139,  'size':1,  'type':'uint', 'post':processAddressedOrBroadcast}},
-    'channel_a_bandwidth': {(22,):  {'start_bit':140,  'size':1,  'type':'uint'}},
-    'channel_b_bandwidth': {(22,):  {'start_bit':141,  'size':1,  'type':'uint'}},
+    {(22,): {'start_bit': 139, 'size': 1, 'type': 'uint',
+             'post': processAddressedOrBroadcast}},
+    'channel_a_bandwidth': {(22,): {'start_bit': 140, 'size': 1, 'type': 'uint'}},
+    'channel_b_bandwidth': {(22,): {'start_bit': 141, 'size': 1, 'type': 'uint'}},
     'transitional_zone_size':
-                           {(22,):  {'start_bit':142,  'size':3,  'type':'uint', 'post':processTransitionalZoneSize}},
-    'station_type':        {(23,):  {'start_bit':110,  'size':4,  'type':'uint'}},
-    'reporting_interval':  {(23,):  {'start_bit':146,  'size':4,  'type':'uint'}},
-    'quiet_time':          {(23,):  {'start_bit':150,  'size':4,  'type':'uint'}},
-    'vendor_id':           {('24B',):
-                                    {'start_bit':48,   'size':42, 'type':'bits', 'post':processVendorID}},
-    'position_latency':    {(27,):  {'start_bit':94,   'size':1,  'type':'uint'}},
+    {(22,): {'start_bit': 142, 'size': 3, 'type': 'uint',
+             'post': processTransitionalZoneSize}},
+    'station_type': {(23,): {'start_bit': 110, 'size': 4, 'type': 'uint'}},
+    'reporting_interval': {(23,): {'start_bit': 146, 'size': 4, 'type': 'uint'}},
+    'quiet_time': {(23,): {'start_bit': 150, 'size': 4, 'type': 'uint'}},
+    'vendor_id': {('24B',):
+                  {'start_bit': 48, 'size': 42, 'type': 'bits', 'post': processVendorID}},
+    'position_latency': {(27,): {'start_bit': 94, 'size': 1, 'type': 'uint'}},
 
 }
+
 
 class AISDecoder:
 
@@ -552,33 +689,37 @@ class AISDecoder:
     def addNMEA(self, nmea):
         parts = nmea.split(',')
         self.last_nmea_parts = parts
-        #print(parts)
+        # print(parts)
         if len(parts) >= 7:
             try:
                 fragment_count = int(parts[1])
-            except:
+            except BaseException:
                 return
             try:
                 fragment_number = int(parts[2])
-            except:
+            except BaseException:
                 return
             channel = parts[4]
             payload = parts[5]
             if fragment_count == 1:
-                #complete message in single nmea sentance
+                # complete message in single nmea sentance
                 self.addMessage(decodePayload(payload, channel, (nmea,)))
             else:
-                if not channel in self.pendingMessages or self.pendingMessages[channel] is None:
-                    self.pendingMessages[channel] = {'nmea':[]}
+                if channel not in self.pendingMessages or self.pendingMessages[channel] is None:
+                    self.pendingMessages[channel] = {'nmea': []}
                 self.pendingMessages[channel][fragment_number] = payload
                 self.pendingMessages[channel]['nmea'].append(nmea)
                 if len(self.pendingMessages[channel]) == fragment_count:
                     # we should have all the fragments now
                     combined_payload = ''
                     try:
-                        for i in range(1,fragment_count+1):
+                        for i in range(1, fragment_count + 1):
                             combined_payload += self.pendingMessages[channel][i]
-                        self.addMessage(decodePayload(combined_payload, channel,self.pendingMessages[channel]['nmea']))
+                        self.addMessage(
+                            decodePayload(
+                                combined_payload,
+                                channel,
+                                self.pendingMessages[channel]['nmea']))
                     except KeyError:
                         pass
                 self.pendingMessages[channel] = None
@@ -588,58 +729,66 @@ class AISDecoder:
         self.decodedMessages = []
         return ret
 
-                
-    def addMessage(self,msg):
+    def addMessage(self, msg):
         self.decodedMessages.append(msg)
 
 
 if __name__ == '__main__':
     import sys
-    
+
     d = AISDecoder()
 
     bin_msg_types = {}
     msg_types = {}
-    
+
     total = 0
     try:
         for fname in sys.argv[1:]:
             print(fname)
-            for l in open(fname).readlines():
-                if l.startswith('!AIVDM'):
-                    parts = (None,l)
+            for line in open(fname).readlines():
+                if line.startswith('!AIVDM'):
+                    parts = (None, line)
                 else:
-                    parts = l.strip().split(',',1)
+                    parts = line.strip().split(',', 1)
                 if len(parts) > 1 and len(parts[1]) > 1:
                     if parts[1].startswith('!AIVDM'):
                         try:
                             d.addNMEA(parts[1])
-                        except Exception as e:
-                            print("Error parsing:", d.last_nmea_parts, ' pending: ', d.pendingMessages)
+                        except Exception:
+                            print(
+                                'Error parsing:',
+                                d.last_nmea_parts,
+                                'pending:',
+                                d.pendingMessages)
                             raise
                         for m in d.popMessages():
 
                             # if m['message_id'] in (27,):
                             #     print (m)
 
-                            if m['message_id'] in (6,8):
-                                dac_fid = str(m['binary_data']['application_identifier']['designated_area_code'])+','+str(m['binary_data']['application_identifier']['function_identifier'])
-                                if not dac_fid in bin_msg_types:
+                            if m['message_id'] in (6, 8):
+                                app_id = m['binary_data'][
+                                    'application_identifier']
+                                dac_fid = (
+                                    str(app_id['designated_area_code'])
+                                    + ','
+                                    + str(app_id['function_identifier'])
+                                )
+                                if dac_fid not in bin_msg_types:
                                     bin_msg_types[dac_fid] = 0
-                                bin_msg_types[dac_fid] = bin_msg_types[dac_fid]+1
+                                bin_msg_types[dac_fid] = bin_msg_types[dac_fid] + 1
                             if not m['message_id'] in msg_types:
                                 msg_types[m['message_id']] = 0
                             msg_types[m['message_id']] += 1
                             total += 1
-                            if total%10000 == 0:
-                                print (total)
+                            if total % 10000 == 0:
+                                print(total)
     except KeyboardInterrupt:
         pass
-    print (total,'ais messages seen.')
-    print ('types seen:')
+    print(total, 'ais messages seen.')
+    print('types seen:')
     for k in sorted(msg_types.keys()):
-        print ('\ttype:',k,'count:', msg_types[k])
-    print ('bin msgs seen:')
+        print('\ttype:', k, 'count:', msg_types[k])
+    print('bin msgs seen:')
     for k in sorted(bin_msg_types):
-        print ('\tdac,fi',k,'count:',bin_msg_types[k])
-
+        print('\tdac,fi', k, 'count:', bin_msg_types[k])

--- a/marine_ais_tools/marine_ais_tools/ais/decoder.py
+++ b/marine_ais_tools/marine_ais_tools/ais/decoder.py
@@ -261,7 +261,7 @@ def processUTCTime(message):
     try:
         message['utc_time'] = datetime.datetime(
             year, month, day, hour, minute, second, tzinfo=datetime.timezone.utc)
-    except BaseException:
+    except (ValueError, OverflowError):
         message['utc_time'] = None
 
 
@@ -693,16 +693,16 @@ class AISDecoder:
         if len(parts) >= 7:
             try:
                 fragment_count = int(parts[1])
-            except BaseException:
+            except (ValueError, IndexError):
                 return
             try:
                 fragment_number = int(parts[2])
-            except BaseException:
+            except (ValueError, IndexError):
                 return
             channel = parts[4]
             payload = parts[5]
             if fragment_count == 1:
-                # complete message in single nmea sentance
+                # complete message in single nmea sentence
                 self.addMessage(decodePayload(payload, channel, (nmea,)))
             else:
                 if channel not in self.pendingMessages or self.pendingMessages[channel] is None:

--- a/marine_ais_tools/marine_ais_tools/ais_contact_tracker.py
+++ b/marine_ais_tools/marine_ais_tools/ais_contact_tracker.py
@@ -1,13 +1,42 @@
 #!/usr/bin/env python3
 
-import rclpy
-import rclpy.node
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
-from marine_ais_msgs.msg import AIS, AISContact, Static
-from geometry_msgs.msg import Polygon, Point32
-from geographic_msgs.msg import GeoPointStamped
 
 import copy
+
+from geographic_msgs.msg import GeoPointStamped
+from geometry_msgs.msg import Point32, Polygon
+from marine_ais_msgs.msg import AIS, AISContact, Static
+import rclpy
+import rclpy.node
 
 
 def calculatePolygon(static: Static):
@@ -16,12 +45,13 @@ def calculatePolygon(static: Static):
     # x forward, y left, z up
     bow = Point32()
     bow.x = static.reference_to_bow_distance
-    width = static.reference_to_port_distance + static.reference_to_starboard_distance
-    half_width = width/2.0
-    bow.y = half_width-static.reference_to_port_distance
+    width = static.reference_to_port_distance + \
+        static.reference_to_starboard_distance
+    half_width = width / 2.0
+    bow.y = half_width - static.reference_to_port_distance
     length = static.reference_to_bow_distance + static.reference_to_stern_distance
     port_pointy_start = Point32()
-    port_pointy_start.x = bow.x-(length*0.1)
+    port_pointy_start.x = bow.x - (length * 0.1)
     port_pointy_start.y = static.reference_to_port_distance
     starboard_pointy_start = Point32()
     starboard_pointy_start.x = port_pointy_start.x
@@ -43,8 +73,8 @@ def calculatePolygon(static: Static):
     return footprint
 
 
-
 class AisContactTracker(rclpy.node.Node):
+
     def __init__(self):
         super().__init__('ais_contact_tracker')
 
@@ -55,32 +85,46 @@ class AisContactTracker(rclpy.node.Node):
         self.aton_pub = self.create_publisher(GeoPointStamped, 'atons', 10)
 
         self.contacts = {}
-        
-        self.ais_message_sub = self.create_subscription(AIS, 'messages', self.aisCallback, 10)
 
+        self.ais_message_sub = self.create_subscription(
+            AIS, 'messages', self.aisCallback, 10)
 
     def aisCallback(self, msg: AIS):
-        if msg.message_id in (1,2,3,5,9,18,19,24):
-            if not msg.id in self.contacts:
+        if msg.message_id in (1, 2, 3, 5, 9, 18, 19, 24):
+            if msg.id not in self.contacts:
                 self.contacts[msg.id] = AISContact()
                 self.contacts[msg.id].id = msg.id
-            if msg.message_id in (5,24): # static/voyage
+            if msg.message_id in (5, 24):  # static/voyage
                 if msg.message_id == 5:
-                    self.contacts[msg.id].static_info = copy.deepcopy(msg.static_info)
+                    self.contacts[msg.id].static_info = copy.deepcopy(
+                        msg.static_info)
                     self.contacts[msg.id].voyage = copy.deepcopy(msg.voyage)
                 else:
-                    if msg.class_b.part_number == 0: # 24A
+                    if msg.class_b.part_number == 0:  # 24A
                         self.contacts[msg.id].static_info.name = msg.static_info.name
-                        self.contacts[msg.id].footprint = calculatePolygon(self.contacts[msg.id].static_info)
-                    else: # 24B
+                        self.contacts[msg.id].footprint = calculatePolygon(
+                            self.contacts[msg.id].static_info)
+                    else:  # 24B
                         self.contacts[msg.id].static_info.callsign = msg.static_info.callsign
-                        self.contacts[msg.id].static_info.ship_and_cargo_type = msg.static_info.ship_and_cargo_type
-                        self.contacts[msg.id].static_info.reference_to_bow_distance = msg.static_info.reference_to_bow_distance
-                        self.contacts[msg.id].static_info.reference_to_stern_distance = msg.static_info.reference_to_stern_distance
-                        self.contacts[msg.id].static_info.reference_to_port_distance = msg.static_info.reference_to_port_distance
-                        self.contacts[msg.id].static_info.reference_to_starboard_distance = msg.static_info.reference_to_starboard_distance
-                        self.contacts[msg.id].footprint = calculatePolygon(self.contacts[msg.id].static_info)
-            if msg.message_id in (1,2,3,9,18,19):
+                        self.contacts[msg.id].static_info \
+                            .ship_and_cargo_type = \
+                            msg.static_info.ship_and_cargo_type
+                        self.contacts[msg.id].static_info \
+                            .reference_to_bow_distance = \
+                            msg.static_info.reference_to_bow_distance
+                        self.contacts[msg.id].static_info \
+                            .reference_to_stern_distance = \
+                            msg.static_info.reference_to_stern_distance
+                        self.contacts[msg.id].static_info \
+                            .reference_to_port_distance = \
+                            msg.static_info.reference_to_port_distance
+                        self.contacts[msg.id].static_info \
+                            .reference_to_starboard_distance = \
+                            msg.static_info \
+                            .reference_to_starboard_distance
+                        self.contacts[msg.id].footprint = calculatePolygon(
+                            self.contacts[msg.id].static_info)
+            if msg.message_id in (1, 2, 3, 9, 18, 19):
                 self.contacts[msg.id].header = msg.header
                 self.contacts[msg.id].position_message_id = msg.message_id
                 self.contacts[msg.id].pose = msg.navigation.pose
@@ -90,12 +134,13 @@ class AisContactTracker(rclpy.node.Node):
 
                 self.contacts_pub.publish(self.contacts[msg.id])
         if msg.message_id == 21:
-            #Aid to Navigation
+            # Aid to Navigation
             aton = GeoPointStamped()
             aton.header.stamp = msg.header.stamp
             aton.header.frame_id = str(msg.id)
             aton.position = msg.navigation.pose.position
             self.aton_pub.publish(aton)
+
 
 def main(args=None):
     rclpy.init(args=args)
@@ -103,7 +148,6 @@ def main(args=None):
     rclpy.spin(tracker)
     rclpy.shutdown()
 
+
 if __name__ == '__main__':
     main()
-
-

--- a/marine_ais_tools/marine_ais_tools/ais_parser.py
+++ b/marine_ais_tools/marine_ais_tools/ais_parser.py
@@ -1,35 +1,70 @@
 #!/usr/bin/env python3
 
-from typing import List
-import rclpy
-import rclpy.node
-import rclpy.constants
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 
-from marine_ais_msgs.msg import AIS, Communication, Destination, DataLinkReservationBlock, Navigation, NavigationalStatus
-from nmea_msgs.msg import Sentence
-
-import transforms3d
-
-import marine_ais_tools.ais.decoder
-
-import math
 import datetime
+import math
+
+from marine_ais_msgs.msg import (
+    AIS, Communication, DataLinkReservationBlock,
+    Destination, Navigation, NavigationalStatus,
+)
+import marine_ais_tools.ais.decoder
+from nmea_msgs.msg import Sentence
+import rclpy
+import rclpy.constants
+import rclpy.node
+import transforms3d
 
 
 class AISParser(rclpy.node.Node):
+
     def __init__(self) -> None:
         super().__init__('ais_parser')
 
         self.ais_pub = self.create_publisher(AIS, 'messages', 10)
         self.ais_decoder = marine_ais_tools.ais.decoder.AISDecoder()
-        self.nmea_sub = self.create_subscription(Sentence, 'nmea', self.nmeaCallback, 10)            
+        self.nmea_sub = self.create_subscription(
+            Sentence, 'nmea', self.nmeaCallback, 10)
 
     def nmeaCallback(self, msg: Sentence):
         if msg.sentence.startswith('!AIVDM'):
             self.ais_decoder.addNMEA(msg.sentence)
             msgs = self.ais_decoder.popMessages()
-            receive_time = datetime.datetime.fromtimestamp(msg.header.stamp.sec + msg.header.stamp.nanosec / float(rclpy.constants.S_TO_NS), datetime.timezone.utc)
+            receive_time = datetime.datetime.fromtimestamp(
+                msg.header.stamp.sec +
+                msg.header.stamp.nanosec /
+                float(
+                    rclpy.constants.S_TO_NS),
+                datetime.timezone.utc)
             for m in msgs:
                 a = AIS()
                 a.header = msg.header
@@ -39,7 +74,8 @@ class AISParser(rclpy.node.Node):
 
                 # navigation
 
-                if 'latitude' in m and 'longitude' in m and m['latitude'] is not None and m['longitude'] is not None:
+                if 'latitude' in m and 'longitude' in m and m[
+                        'latitude'] is not None and m['longitude'] is not None:
                     a.navigation.pose.position.latitude = m['latitude']
                     a.navigation.pose.position.longitude = m['longitude']
                 else:
@@ -51,7 +87,7 @@ class AISParser(rclpy.node.Node):
                     a.navigation.pose.position.altitude = math.nan
 
                 if 'true_heading' in m and m['true_heading'] is not None:
-                    yaw = math.radians(90.0-m['true_heading'])
+                    yaw = math.radians(90.0 - m['true_heading'])
                     q = transforms3d.taitbryan.euler2quat(yaw, 0, 0)
                     a.navigation.pose.orientation.x = q[1]
                     a.navigation.pose.orientation.y = q[2]
@@ -67,17 +103,20 @@ class AISParser(rclpy.node.Node):
                             a.navigation.rate_of_turn_status = Navigation.RATE_OF_TURN_UNAVAILABLE
                     else:
                         # from deg/min clockwise to rad/sec counter clockwise
-                        a.navigation.twist.angular.z = math.radians(-m['rate_of_turn']/60.0)
+                        a.navigation.twist.angular.z = math.radians(
+                            -m['rate_of_turn'] / 60.0)
                         a.navigation.rate_of_turn_status = Navigation.RATE_OF_TURN_VALID
                 else:
                     a.navigation.twist.angular.z = math.nan
                     a.navigation.rate_of_turn_status = Navigation.RATE_OF_TURN_UNAVAILABLE
 
                 if 'sog' in m and m['sog'] is not None and 'cog' in m and m['cog'] is not None:
-                    sog_meters_per_second = m['sog']*0.514444
-                    cog_ros = math.radians(90.0-m['cog'])
-                    a.navigation.twist.linear.x = math.cos(cog_ros)*sog_meters_per_second
-                    a.navigation.twist.linear.y = math.sin(cog_ros)*sog_meters_per_second
+                    sog_meters_per_second = m['sog'] * 0.514444
+                    cog_ros = math.radians(90.0 - m['cog'])
+                    a.navigation.twist.linear.x = math.cos(
+                        cog_ros) * sog_meters_per_second
+                    a.navigation.twist.linear.y = math.sin(
+                        cog_ros) * sog_meters_per_second
                 else:
                     a.navigation.twist.linear.x = math.nan
                     a.navigation.twist.linear.y = math.nan
@@ -85,9 +124,12 @@ class AISParser(rclpy.node.Node):
                 if 'navigational_status' in m:
                     a.navigation.navigational_status.status = m['navigational_status']
                 else:
-                    a.navigation.navigational_status.status = NavigationalStatus.NAVIGATIONAL_STATUS_UNDEFINED
+                    a.navigation.navigational_status.status = (
+                        NavigationalStatus.NAVIGATIONAL_STATUS_UNDEFINED
+                    )
 
-                a.navigation.position_accuracy_high = 'position_accuracy' in m and m['position_accuracy'] == 1
+                a.navigation.position_accuracy_high = 'position_accuracy' in m and m[
+                    'position_accuracy'] == 1
 
                 if 'time_stamp' in m:
                     a.navigation.time_stamp = m['time_stamp']
@@ -95,32 +137,35 @@ class AISParser(rclpy.node.Node):
                     a.navigation.time_stamp = Navigation.TIME_STAMP_NOT_AVAIABLE
 
                 if 'special_manoeuvre_indicator' in m:
-                    a.navigation.navigational_status.special_manoeuvre = m['special_manoeuvre_indicator']
+                    a.navigation.navigational_status.special_manoeuvre = m[
+                        'special_manoeuvre_indicator']
 
                 a.navigation.raim_in_use = 'raim_flag' in m and m['raim_flag'] == 1
 
                 if 'position_fixing_device_type' in m:
                     a.navigation.position_fixing_device_type = m['position_fixing_device_type']
 
-                a.navigation.barometric_altitude = 'altitude_sensor' in m and m['altitude_sensor'] == 1
+                a.navigation.barometric_altitude = 'altitude_sensor' in m and m[
+                    'altitude_sensor'] == 1
 
                 if 'position_latency' in m:
                     a.navigation.position_latency = m['position_latency']
                 a.navigation.position_latency = 1
 
-                a.navigation.assigned_mode = 'assigned_mode_flag' in m and m['assigned_mode_flag'] ==1
+                a.navigation.assigned_mode = 'assigned_mode_flag' in m and m[
+                    'assigned_mode_flag'] == 1
 
                 # Static
 
                 if 'ais_version' in m:
                     a.static_info.ais_version = m['ais_version']
-                
+
                 if 'imo_number' in m:
                     a.static_info.imo_number = m['imo_number']
-                
+
                 if 'callsign' in m:
                     a.static_info.callsign = m['callsign']
-                
+
                 if 'name' in m:
                     a.static_info.name = m['name']
 
@@ -137,13 +182,16 @@ class AISParser(rclpy.node.Node):
                     a.static_info.reference_to_port_distance = m['reference_to_port_distance']
 
                 if 'reference_to_starboard_distance' in m:
-                    a.static_info.reference_to_starboard_distance = m['reference_to_starboard_distance']
+                    a.static_info.reference_to_starboard_distance = (
+                        m['reference_to_starboard_distance']
+                    )
 
-                if 'maximum_present_static_draught' in m and m['maximum_present_static_draught'] is not None:
+                if 'maximum_present_static_draught' in m and m[
+                        'maximum_present_static_draught'] is not None:
                     a.static_info.static_draught = m['maximum_present_static_draught']
 
                 if 'dte' in m:
-                    a.static_info.dte_ready =  m['dte'] == 0
+                    a.static_info.dte_ready = m['dte'] == 0
                 else:
                     a.static_info.dte_ready = False
 
@@ -156,7 +204,7 @@ class AISParser(rclpy.node.Node):
                 if 'eta_month' in m:
                     if m['eta_month'] > 0:
                         month == m['eta_month']
-                        if month < receive_time.month: # next year?
+                        if month < receive_time.month:  # next year?
                             year += 1
                         eta_parts_available = True
                 day = receive_time.day
@@ -177,7 +225,15 @@ class AISParser(rclpy.node.Node):
 
                 if eta_parts_available:
                     try:
-                        a.voyage.estimated_time_of_arrival = rclpy.time.Time(seconds=datetime.datetime(year, month, day, hour, minute, tzinfo=datetime.timezone.utc).timestamp()).to_msg()
+                        eta_dt = datetime.datetime(
+                            year, month, day, hour, minute,
+                            tzinfo=datetime.timezone.utc,
+                        )
+                        a.voyage.estimated_time_of_arrival = (
+                            rclpy.time.Time(
+                                seconds=eta_dt.timestamp()
+                            ).to_msg()
+                        )
                     except ValueError:
                         s = "Can't decode eta from:\n" + str(m)
                         self.get_logger().warn(s)
@@ -211,7 +267,7 @@ class AISParser(rclpy.node.Node):
                         if 'slot_offset_1_2' in m:
                             d.slot_offset = m['slot_offset_1_2']
                         a.addressed.destinations.append(d)
-                
+
                 if 'destination_id2' in m:
                     d = Destination()
                     d.id = m['destination_id2']
@@ -222,7 +278,7 @@ class AISParser(rclpy.node.Node):
                     if 'slot_offset_2_1' in m:
                         d.slot_offset = m['slot_offset_2_1']
                     a.addressed.destinations.append(d)
-                
+
                 if 'destination_id3' in m:
                     d = Destination()
                     d.id = m['destination_id3']
@@ -236,7 +292,7 @@ class AISParser(rclpy.node.Node):
                     if 'sequence_number_for_id4' in m:
                         d.sequence_number = m['sequence_number_for_id4']
                     a.addressed.destinations.append(d)
-                    
+
                 if 'destination_id_a' in m:
                     d = Destination()
                     d.id = m['destination_id_a']
@@ -245,7 +301,7 @@ class AISParser(rclpy.node.Node):
                     if 'increment_a' in m:
                         d.increment = m['increment_a']
                     a.addressed.destinations.append(d)
-                
+
                 if 'destination_id_b' in m:
                     d = Destination()
                     d.id = m['destination_id_b']
@@ -279,17 +335,19 @@ class AISParser(rclpy.node.Node):
 
                 a.class_b.cs_unit = 'class_b_unit_flag' in m and m['class_b_unit_flag'] == 1
 
-                a.class_b.display_equipped = 'class_b_display_flag' in m and m['class_b_display_flag'] == 1
+                a.class_b.display_equipped = 'class_b_display_flag' in m and m[
+                    'class_b_display_flag'] == 1
 
                 a.class_b.dsc_equipped = 'class_b_dsc_flag' in m and m['class_b_dsc_flag'] == 1
 
                 a.class_b.whole_band = 'class_b_band_flag' in m and m['class_b_band_flag'] == 1
 
-                a.class_b.message_22_frequency_management = 'class_b_message_22_flag' in m and m['class_b_message_22_flag'] == 1
+                a.class_b.message_22_frequency_management = 'class_b_message_22_flag' in m and m[
+                    'class_b_message_22_flag'] == 1
 
                 if 'part_number' in m:
                     a.class_b.part_number = m['part_number']
-                
+
                 if 'vendor_id' in m:
                     vid = m['vendor_id']
                     if 'manufacturers_id' in vid:
@@ -303,23 +361,24 @@ class AISParser(rclpy.node.Node):
 
                 for n in ('1', '2', '3', '4'):
 
-                    if 'offset_number_'+n in m:
+                    if 'offset_number_' + n in m:
                         dlrb = DataLinkReservationBlock()
-                        dlrb.offset_number = m['offset_number_'+n]
+                        dlrb.offset_number = m['offset_number_' + n]
 
-                        if 'number_of_slots_'+n in m:
-                            dlrb.number_of_slots = m['number_of_slots_'+n]
-                        if 'timeout_'+n in m:
-                            dlrb.timeout = rclpy.duration.Duration(seconds=60*m['timeout_'+n]).to_msg()
-                        if 'increment_'+n in m:
-                            dlrb.increment = m['increment_'+n]
+                        if 'number_of_slots_' + n in m:
+                            dlrb.number_of_slots = m['number_of_slots_' + n]
+                        if 'timeout_' + n in m:
+                            dlrb.timeout = rclpy.duration.Duration(
+                                seconds=60 * m['timeout_' + n]).to_msg()
+                        if 'increment_' + n in m:
+                            dlrb.increment = m['increment_' + n]
                         a.data_link_reservation_blocks.append(dlrb)
 
                 # Aids to Navigation
 
                 if 'type_of_aids_to_navigation' in m:
                     a.aton.type = m['type_of_aids_to_navigation']
-                
+
                 if 'name_of_aids_navigation' in m:
                     a.static_info.name = m['name_of_aids_navigation']
 
@@ -337,19 +396,19 @@ class AISParser(rclpy.node.Node):
 
                 # Communication
 
-                if m['message_id'] in (1,2,4,11):
+                if m['message_id'] in (1, 2, 4, 11):
                     a.communication.state = Communication.COMMUNICATION_STATE_SOTDMA
                 elif m['message_id'] == 3:
                     a.communication.state = Communication.COMMUNICATION_STATE_ITDMA
                 elif 'communication_state_selector_flag' in m:
                     a.communication.state = m['communication_state_selector_flag']
-                
+
                 if 'sotdma_sync_state' in m:
                     a.communication.sync_state = m['sotdma_sync_state']
 
                 if 'sotdma_slot_timeout' in m:
                     a.communication.sotdma_slot_timeout = m['sotdma_slot_timeout']
-                
+
                 if 'sotdma_received_stations' in m:
                     a.communication.sotdma_received_stations = m['sotdma_received_stations']
 
@@ -381,11 +440,14 @@ class AISParser(rclpy.node.Node):
 
                 if 'utc_time' in m and m['utc_time'] is not None:
                     try:
-                        a.utc_time = rclpy.time.Time(seconds=m['utc_time'].timestamp()).to_msg()
+                        a.utc_time = rclpy.time.Time(
+                            seconds=m['utc_time'].timestamp()).to_msg()
                     except TypeError:
-                        self.get_logger().error('utc_time: '+ str(m['utc_time']))
+                        self.get_logger().error(
+                            'utc_time: ' + str(m['utc_time']))
 
-                a.long_range_transmission_control = 'long_range_transmission_control' in m and m['long_range_transmission_control'] == 1
+                a.long_range_transmission_control = 'long_range_transmission_control' in m and m[
+                    'long_range_transmission_control'] == 1
 
                 if 'safety_related_text' in m:
                     a.safety_related_text = m['safety_related_text']
@@ -400,8 +462,6 @@ class AISParser(rclpy.node.Node):
                     self.ais_pub.publish(a)
                 except Exception as e:
                     self.get_logger().error(str(e))
-
-
 
 
 def main(args=None):

--- a/marine_ais_tools/marine_ais_tools/nmea_relay.py
+++ b/marine_ais_tools/marine_ais_tools/nmea_relay.py
@@ -1,15 +1,47 @@
 #!/usr/bin/env python3
 
-import os
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
-import serial
+
+import datetime
+import os
 import socket
+
+from nmea_msgs.msg import Sentence
 import rclpy
 import rclpy.node
-from nmea_msgs.msg import Sentence
-import datetime
+import serial
+
 
 class SerialReader:
+
     def __init__(self, address, speed):
         self.serial_in = serial.Serial(address, speed)
 
@@ -17,7 +49,9 @@ class SerialReader:
         nmea_in = self.serial_in.readline()
         return [nmea_in.decode('utf-8').strip()]
 
+
 class UDPReader:
+
     def __init__(self, port):
         self.udp_in = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.udp_in.settimeout(0.1)
@@ -34,7 +68,9 @@ class UDPReader:
             ret.append(n.strip())
         return ret
 
+
 class TCPReader:
+
     def __init__(self, address, port):
         self.tcp_in = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.tcp_in.settimeout(0.1)
@@ -44,7 +80,7 @@ class TCPReader:
     def readlines(self):
         try:
             nmea_in = self.tcp_in.recv(256)
-            nmea_ins = (self.leftovers+nmea_in.decode('utf-8')).split('\n')
+            nmea_ins = (self.leftovers + nmea_in.decode('utf-8')).split('\n')
             if len(nmea_ins):
                 self.leftovers = nmea_ins[-1]
                 ret = []
@@ -55,7 +91,9 @@ class TCPReader:
             pass
         return []
 
+
 class NMEARelay(rclpy.node.Node):
+
     def __init__(self) -> None:
         super().__init__('nmea_relay')
 
@@ -86,7 +124,14 @@ class NMEARelay(rclpy.node.Node):
         log_directory = self.get_parameter('log_directory').value
 
         if log_directory is not None and log_directory != '':
-            logfile = open(os.path.join(log_directory, 'ais_'+'.'.join(datetime.datetime.utcnow().isoformat().split(':'))+'.log'),'w')
+            logfile = open(
+                os.path.join(
+                    log_directory,
+                    'ais_' +
+                    '.'.join(
+                        datetime.datetime.utcnow().isoformat().split(':')) +
+                    '.log'),
+                'w')
         else:
             logfile = None
 
@@ -98,7 +143,10 @@ class NMEARelay(rclpy.node.Node):
             reader = UDPReader(input_port)
 
         if output_port > 0:
-            udp_out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+            udp_out = socket.socket(
+                socket.AF_INET,
+                socket.SOCK_DGRAM,
+                socket.IPPROTO_UDP)
             udp_out.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         else:
             udp_out = None
@@ -109,10 +157,13 @@ class NMEARelay(rclpy.node.Node):
 
             for nmea in nmea_ins:
                 if udp_out is not None:
-                    udp_out.sendto(nmea.encode('utf-8'), (output_address, output_port))
+                    udp_out.sendto(
+                        nmea.encode('utf-8'), (output_address, output_port))
 
                 if logfile is not None:
-                    logfile.write(datetime.datetime.fromtimestamp(now.sec.to_time()).isoformat() + ',' + nmea + '\n')
+                    logfile.write(
+                        datetime.datetime.fromtimestamp(
+                            now.sec.to_time()).isoformat() + ',' + nmea + '\n')
                     logfile.flush()
                 if len(nmea) > 0:
                     sentence = Sentence()
@@ -121,11 +172,13 @@ class NMEARelay(rclpy.node.Node):
                     sentence.sentence = nmea
                     self.nmea_pub.publish(sentence)
 
+
 def main(args=None):
     rclpy.init(args=args)
     relay = NMEARelay()
     rclpy.spin(relay)
     rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/marine_ais_tools/marine_ais_tools/nmea_replay.py
+++ b/marine_ais_tools/marine_ais_tools/nmea_replay.py
@@ -73,54 +73,59 @@ class NMEAReplay(rclpy.node.Node):
         wallclock_start = datetime.datetime.utcnow()
         next_clock_time = wallclock_start
 
-        for line in open(self.input_filename).readlines():
-            timestring, nmea = line.split(',', 1)
-            datatime = datetime.datetime.fromisoformat(timestring)
-            if data_start_time is None:
-                data_start_time = datatime
+        with open(self.input_filename) as f:
+            for line in f:
+                timestring, nmea = line.split(',', 1)
+                datatime = datetime.datetime.fromisoformat(timestring)
+                if data_start_time is None:
+                    data_start_time = datatime
 
-            while nmea is not None:
-                now = datetime.datetime.utcnow()
-                rosnow = data_start_time + \
-                    datetime.timedelta(
-                        seconds=(
-                            now -
-                            wallclock_start).total_seconds() *
-                        self.rate)
-
-                if self.publish_clock and next_clock_time <= now:
-                    rosclock_time = data_start_time + \
+                while nmea is not None:
+                    now = datetime.datetime.utcnow()
+                    rosnow = data_start_time + \
                         datetime.timedelta(
                             seconds=(
-                                next_clock_time -
+                                now -
                                 wallclock_start).total_seconds() *
                             self.rate)
-                    seconds = int(rosclock_time.timestamp())
-                    nanoseconds = rclpy.constants.S_TO_NS * \
-                        (rosclock_time.timestamp() - seconds)
-                    c = Clock()
-                    c.clock = rclpy.time.Time(
-                        seconds=seconds, nanoseconds=nanoseconds).to_msg()
-                    self.clock_publisher.publish(c)
-                    next_clock_time += clock_period
 
-                if datatime <= rosnow:
-                    sentence = Sentence()
-                    sentence.header.frame_id = self.frame_id
-                    seconds = int(datatime.timestamp())
-                    nanoseconds = rclpy.constants.S_TO_NS * \
-                        (datatime.timestamp() - seconds)
-                    sentence.header.stamp = rclpy.time.Time(
-                        seconds=seconds, nanoseconds=nanoseconds).to_msg()
-                    sentence.sentence = nmea
-                    self.nmea_pub.publish(sentence)
-                    nmea = None
-                    break
-                sleeptime = (datatime - rosnow).total_seconds() / self.rate
-                if self.publish_clock:
-                    clocksleeptime = (next_clock_time - now).total_seconds()
-                    sleeptime = min(clocksleeptime, sleeptime)
-                time.sleep(sleeptime)
+                    if self.publish_clock and next_clock_time <= now:
+                        rosclock_time = data_start_time + \
+                            datetime.timedelta(
+                                seconds=(
+                                    next_clock_time -
+                                    wallclock_start).total_seconds() *
+                                self.rate)
+                        seconds = int(rosclock_time.timestamp())
+                        nanoseconds = rclpy.constants.S_TO_NS * \
+                            (rosclock_time.timestamp() - seconds)
+                        c = Clock()
+                        c.clock = rclpy.time.Time(
+                            seconds=seconds,
+                            nanoseconds=nanoseconds).to_msg()
+                        self.clock_publisher.publish(c)
+                        next_clock_time += clock_period
+
+                    if datatime <= rosnow:
+                        sentence = Sentence()
+                        sentence.header.frame_id = self.frame_id
+                        seconds = int(datatime.timestamp())
+                        nanoseconds = rclpy.constants.S_TO_NS * \
+                            (datatime.timestamp() - seconds)
+                        sentence.header.stamp = rclpy.time.Time(
+                            seconds=seconds,
+                            nanoseconds=nanoseconds).to_msg()
+                        sentence.sentence = nmea
+                        self.nmea_pub.publish(sentence)
+                        nmea = None
+                        break
+                    sleeptime = \
+                        (datatime - rosnow).total_seconds() / self.rate
+                    if self.publish_clock:
+                        clocksleeptime = \
+                            (next_clock_time - now).total_seconds()
+                        sleeptime = min(clocksleeptime, sleeptime)
+                    time.sleep(sleeptime)
 
 
 def main(args=None):

--- a/marine_ais_tools/marine_ais_tools/nmea_replay.py
+++ b/marine_ais_tools/marine_ais_tools/nmea_replay.py
@@ -1,82 +1,126 @@
 #!/usr/bin/env python3
 
-import rclpy
-import rclpy.node
-import rclpy.constants
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
-from nmea_msgs.msg import Sentence
-from rosgraph_msgs.msg import Clock
+
 import datetime
 import time
 
+from nmea_msgs.msg import Sentence
+import rclpy
+import rclpy.constants
+import rclpy.node
+from rosgraph_msgs.msg import Clock
+
+
 class NMEAReplay(rclpy.node.Node):
-  def __init__(self):
-    super().__init__('nmea_replay')
 
-    self.declare_parameter("filename", "")
-    self.input_filename = self.get_parameter("filename").value
+    def __init__(self):
+        super().__init__('nmea_replay')
 
-    self.declare_parameter('frame_id', 'nmea')
-    self.frame_id = self.get_parameter('frame_id').value
+        self.declare_parameter('filename', '')
+        self.input_filename = self.get_parameter('filename').value
 
-    self.declare_parameter('rate', 1.0)
-    self.rate = self.get_parameter('rate').value
+        self.declare_parameter('frame_id', 'nmea')
+        self.frame_id = self.get_parameter('frame_id').value
 
-    self.declare_parameter('clock', False)
-    self.publish_clock = self.get_parameter('clock').value
+        self.declare_parameter('rate', 1.0)
+        self.rate = self.get_parameter('rate').value
 
-    self.nmea_pub = self.create_publisher(Sentence, 'nmea', 20)
+        self.declare_parameter('clock', False)
+        self.publish_clock = self.get_parameter('clock').value
 
-    if self.publish_clock:
-      self.clock_publisher = self.create_publisher(Clock, '/clock', 5)
+        self.nmea_pub = self.create_publisher(Sentence, 'nmea', 20)
 
-
-    self.run_timer = self.create_timer(0.0, self.run)
-
-
-  def run(self):
-    self.run_timer.cancel()
-    
-    data_start_time = None
-    clock_period = datetime.timedelta(seconds=0.2)
-
-    wallclock_start = datetime.datetime.utcnow()
-    next_clock_time = wallclock_start
-
-    for line in open(self.input_filename).readlines():
-      timestring,nmea = line.split(',',1)
-      datatime = datetime.datetime.fromisoformat(timestring)
-      if data_start_time is None:
-        data_start_time = datatime
-
-      while nmea is not None:  
-        now = datetime.datetime.utcnow()
-        rosnow = data_start_time+datetime.timedelta(seconds=(now-wallclock_start).total_seconds()*self.rate)
-
-        if self.publish_clock and next_clock_time <= now:
-          rosclock_time = data_start_time+datetime.timedelta(seconds=(next_clock_time-wallclock_start).total_seconds()*self.rate)
-          seconds = int(rosclock_time.timestamp())
-          nanoseconds = rclpy.constants.S_TO_NS*(rosclock_time.timestamp()-seconds)
-          c = Clock()
-          c.clock = rclpy.time.Time(seconds=seconds, nanoseconds=nanoseconds).to_msg()
-          self.clock_publisher.publish(c)
-          next_clock_time += clock_period
-
-        if datatime <= rosnow:
-          sentence = Sentence()
-          sentence.header.frame_id = self.frame_id
-          seconds = int(datatime.timestamp())
-          nanoseconds = rclpy.constants.S_TO_NS*(datatime.timestamp()-seconds)
-          sentence.header.stamp = rclpy.time.Time(seconds=seconds, nanoseconds=nanoseconds).to_msg()
-          sentence.sentence = nmea
-          self.nmea_pub.publish(sentence)
-          nmea = None
-          break
-        sleeptime = (datatime - rosnow).total_seconds()/self.rate
         if self.publish_clock:
-          clocksleeptime = (next_clock_time - now).total_seconds()
-          sleeptime = min(clocksleeptime, sleeptime)
-        time.sleep(sleeptime)
+            self.clock_publisher = self.create_publisher(Clock, '/clock', 5)
+
+        self.run_timer = self.create_timer(0.0, self.run)
+
+    def run(self):
+        self.run_timer.cancel()
+
+        data_start_time = None
+        clock_period = datetime.timedelta(seconds=0.2)
+
+        wallclock_start = datetime.datetime.utcnow()
+        next_clock_time = wallclock_start
+
+        for line in open(self.input_filename).readlines():
+            timestring, nmea = line.split(',', 1)
+            datatime = datetime.datetime.fromisoformat(timestring)
+            if data_start_time is None:
+                data_start_time = datatime
+
+            while nmea is not None:
+                now = datetime.datetime.utcnow()
+                rosnow = data_start_time + \
+                    datetime.timedelta(
+                        seconds=(
+                            now -
+                            wallclock_start).total_seconds() *
+                        self.rate)
+
+                if self.publish_clock and next_clock_time <= now:
+                    rosclock_time = data_start_time + \
+                        datetime.timedelta(
+                            seconds=(
+                                next_clock_time -
+                                wallclock_start).total_seconds() *
+                            self.rate)
+                    seconds = int(rosclock_time.timestamp())
+                    nanoseconds = rclpy.constants.S_TO_NS * \
+                        (rosclock_time.timestamp() - seconds)
+                    c = Clock()
+                    c.clock = rclpy.time.Time(
+                        seconds=seconds, nanoseconds=nanoseconds).to_msg()
+                    self.clock_publisher.publish(c)
+                    next_clock_time += clock_period
+
+                if datatime <= rosnow:
+                    sentence = Sentence()
+                    sentence.header.frame_id = self.frame_id
+                    seconds = int(datatime.timestamp())
+                    nanoseconds = rclpy.constants.S_TO_NS * \
+                        (datatime.timestamp() - seconds)
+                    sentence.header.stamp = rclpy.time.Time(
+                        seconds=seconds, nanoseconds=nanoseconds).to_msg()
+                    sentence.sentence = nmea
+                    self.nmea_pub.publish(sentence)
+                    nmea = None
+                    break
+                sleeptime = (datatime - rosnow).total_seconds() / self.rate
+                if self.publish_clock:
+                    clocksleeptime = (next_clock_time - now).total_seconds()
+                    sleeptime = min(clocksleeptime, sleeptime)
+                time.sleep(sleeptime)
 
 
 def main(args=None):

--- a/marine_ais_tools/setup.py
+++ b/marine_ais_tools/setup.py
@@ -1,6 +1,36 @@
-from setuptools import find_packages, setup
-import os
+# Copyright (c) 2016-2020, Roland Arsenault
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 from glob import glob
+import os
+
+from setuptools import find_packages, setup
 
 package_name = 'marine_ais_tools'
 
@@ -12,8 +42,10 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
-        (os.path.join('share', package_name, 'config'), glob(os.path.join('config', '*.yaml'))),
+        (os.path.join('share', package_name, 'launch'), glob(
+            os.path.join('launch', '*launch.[pxy][yma]*'))),
+        (os.path.join('share', package_name, 'config'),
+         glob(os.path.join('config', '*.yaml'))),
 
     ],
     install_requires=['setuptools'],
@@ -25,10 +57,10 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-          'ais_parser = marine_ais_tools.ais_parser:main',
-          'nmea_relay = marine_ais_tools.nmea_relay:main',
-          'nmea_replay = marine_ais_tools.nmea_replay:main',
-          'ais_contact_tracker = marine_ais_tools.ais_contact_tracker:main',
+            'ais_parser = marine_ais_tools.ais_parser:main',
+            'nmea_relay = marine_ais_tools.nmea_relay:main',
+            'nmea_replay = marine_ais_tools.nmea_replay:main',
+            'ais_contact_tracker = marine_ais_tools.ais_contact_tracker:main',
         ],
     },
 )


### PR DESCRIPTION
## Summary

- Add BSD-3-Clause copyright headers to all Python source files and launch file
- Fix flake8 violations across all modules: line length (E501), import ordering (google style), shadow builtins (A001), ambiguous variable names (E741), unused variables (F841), and quote style (Q000)
- Use asterisk bullet format in license headers for ament_copyright compatibility

## Test plan

- [x] `colcon build --packages-select marine_ais_tools` succeeds
- [x] `colcon test --packages-select marine_ais_tools` passes all 3 tests (test_copyright, test_flake8, test_pep257) with 0 failures

Closes #4

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
